### PR TITLE
fix: patch known-safe dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"emailjs-com": "3.2.0",
 				"framer-motion": "11.9.0",
 				"graphql": "16.9.0",
-				"next": "14.2.13",
+				"next": "14.2.35",
 				"next-share": "0.27.0",
 				"react": "18.3.1",
 				"react-dom": "18.3.1",
@@ -89,38 +89,25 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
-			"integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.25.7",
-				"picocolors": "^1.0.0"
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.25.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.8.tgz",
-			"integrity": "sha512-ZsysZyXY4Tlx+Q53XdnOFmqwfB9QDTHYxaZYajWRoBLuLEAwI2UIbtxOjWh/cFaa9IKUlcB+DDuoskLuKu56JA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -128,22 +115,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.25.8",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.8.tgz",
-			"integrity": "sha512-Oixnb+DzmRT30qu9d3tJSQkxuygWm32DFykT4bRoORPa9hZ/L4KhVB/XiRm6KG+roIEM7DBQlmg27kw2HZkdZg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.25.7",
-				"@babel/generator": "^7.25.7",
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helpers": "^7.25.7",
-				"@babel/parser": "^7.25.8",
-				"@babel/template": "^7.25.7",
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.8",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -169,15 +156,16 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
-			"integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.25.7",
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.25",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
 			},
 			"engines": {
@@ -212,14 +200,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.7.tgz",
-			"integrity": "sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.25.7",
-				"@babel/helper-validator-option": "^7.25.7",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -315,6 +303,16 @@
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.7.tgz",
@@ -330,30 +328,29 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
-			"integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.7.tgz",
-			"integrity": "sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.25.7",
-				"@babel/helper-simple-access": "^7.25.7",
-				"@babel/helper-validator-identifier": "^7.25.7",
-				"@babel/traverse": "^7.25.7"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -376,9 +373,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.7.tgz",
-			"integrity": "sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+			"integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -450,9 +447,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
-			"integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -460,9 +457,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-			"integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -470,9 +467,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz",
-			"integrity": "sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -495,43 +492,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.7.tgz",
-			"integrity": "sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.25.7",
-				"@babel/types": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-			"integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.25.7",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.25.8",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
-			"integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.25.8"
+				"@babel/types": "^7.29.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1150,16 +1131,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.7.tgz",
-			"integrity": "sha512-t9jZIvBmOXJsiuyOwhrIGs8dVcD6jDyg2icw1VL4A/g+FnWyJKwUfSSU2nwJuMV2Zqui856El9u+ElB+j9fV1g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+			"integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-validator-identifier": "^7.25.7",
-				"@babel/traverse": "^7.25.7"
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helper-plugin-utils": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1836,62 +1817,58 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-			"integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
-			"integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/types": "^7.25.7"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
-			"integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.25.7",
-				"@babel/generator": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/template": "^7.25.7",
-				"@babel/types": "^7.25.7",
-				"debug": "^4.3.1",
-				"globals": "^11.1.0"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"debug": "^4.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.25.8",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
-			"integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.25.7",
-				"@babel/helper-validator-identifier": "^7.25.7",
-				"to-fast-properties": "^2.0.0"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1984,9 +1961,9 @@
 			}
 		},
 		"node_modules/@commitlint/config-validator/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2435,9 +2412,9 @@
 			}
 		},
 		"node_modules/@cypress/request": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.5.tgz",
-			"integrity": "sha512-v+XHd9XmWbufxF1/bTaVm2yhbxY+TB4YtWRqF2zaXBlDNMkls34KiATz0AVDLavL3iB6bQk9/7n3oY1EoLSWGA==",
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
+			"integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2447,16 +2424,16 @@
 				"combined-stream": "~1.0.6",
 				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
-				"form-data": "~4.0.0",
+				"form-data": "~4.0.4",
 				"http-signature": "~1.4.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
 				"json-stringify-safe": "~5.0.1",
 				"mime-types": "~2.1.19",
 				"performance-now": "^2.1.0",
-				"qs": "6.13.0",
+				"qs": "~6.14.1",
 				"safe-buffer": "^5.1.2",
-				"tough-cookie": "^4.1.3",
+				"tough-cookie": "^5.0.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^8.3.2"
 			},
@@ -2464,14 +2441,20 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/@cypress/request/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+		"node_modules/@cypress/request/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
 			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/@cypress/xvfb": {
@@ -3050,14 +3033,29 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-			"integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+			"integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
+				"@eslint/core": "^0.13.0",
 				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+			"integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3615,34 +3613,31 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"devOptional": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -3668,9 +3663,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3769,9 +3764,9 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "14.2.13",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.13.tgz",
-			"integrity": "sha512-s3lh6K8cbW1h5Nga7NNeXrbe0+2jIIYK9YaA9T7IufDWnZpozdFUp6Hf0d5rNWUKu4fEuSX2rCKlGjCrtylfDw==",
+			"version": "14.2.35",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+			"integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
 			"license": "MIT"
 		},
 		"node_modules/@next/eslint-plugin-next": {
@@ -3785,9 +3780,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "14.2.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.13.tgz",
-			"integrity": "sha512-IkAmQEa2Htq+wHACBxOsslt+jMoV3msvxCn0WFSfJSkv/scy+i/EukBKNad36grRxywaXUYJc9mxEGkeIs8Bzg==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+			"integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3801,9 +3796,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "14.2.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.13.tgz",
-			"integrity": "sha512-Dv1RBGs2TTjkwEnFMVL5XIfJEavnLqqwYSD6LXgTPdEy/u6FlSrLBSSfe1pcfqhFEXRAgVL3Wpjibe5wXJzWog==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+			"integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
 			"cpu": [
 				"x64"
 			],
@@ -3817,9 +3812,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "14.2.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.13.tgz",
-			"integrity": "sha512-yB1tYEFFqo4ZNWkwrJultbsw7NPAAxlPXURXioRl9SdW6aIefOLS+0TEsKrWBtbJ9moTDgU3HRILL6QBQnMevg==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+			"integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3833,9 +3828,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "14.2.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.13.tgz",
-			"integrity": "sha512-v5jZ/FV/eHGoWhMKYrsAweQ7CWb8xsWGM/8m1mwwZQ/sutJjoFaXchwK4pX8NqwImILEvQmZWyb8pPTcP7htWg==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+			"integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3849,9 +3844,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "14.2.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.13.tgz",
-			"integrity": "sha512-aVc7m4YL7ViiRv7SOXK3RplXzOEe/qQzRA5R2vpXboHABs3w8vtFslGTz+5tKiQzWUmTmBNVW0UQdhkKRORmGA==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+			"integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
 			"cpu": [
 				"x64"
 			],
@@ -3865,9 +3860,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "14.2.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.13.tgz",
-			"integrity": "sha512-4wWY7/OsSaJOOKvMsu1Teylku7vKyTuocvDLTZQq0TYv9OjiYYWt63PiE1nTuZnqQ4RPvME7Xai+9enoiN0Wrg==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+			"integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
 			"cpu": [
 				"x64"
 			],
@@ -3881,9 +3876,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "14.2.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.13.tgz",
-			"integrity": "sha512-uP1XkqCqV2NVH9+g2sC7qIw+w2tRbcMiXFEbMihkQ8B1+V6m28sshBwAB0SDmOe0u44ne1vFU66+gx/28RsBVQ==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+			"integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3897,9 +3892,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "14.2.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.13.tgz",
-			"integrity": "sha512-V26ezyjPqQpDBV4lcWIh8B/QICQ4v+M5Bo9ykLN+sqeKKBxJVDpEc6biDVyluTXTC40f5IqCU0ttth7Es2ZuMw==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+			"integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -3913,9 +3908,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "14.2.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.13.tgz",
-			"integrity": "sha512-WwzOEAFBGhlDHE5Z73mNU8CO8mqMNLqaG+AO9ETmzdCQlJhVtWZnOl2+rqgVQS+YHunjOWptdFmNfbpwcUuEsw==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+			"integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
 			"cpu": [
 				"x64"
 			],
@@ -4006,17 +4001,34 @@
 			}
 		},
 		"node_modules/@octokit/endpoint": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
-			"integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+			"version": "10.1.4",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+			"integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^13.0.0",
+				"@octokit/types": "^14.0.0",
 				"universal-user-agent": "^7.0.2"
 			},
 			"engines": {
 				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+			"version": "25.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+			"integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+			"integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^25.1.0"
 			}
 		},
 		"node_modules/@octokit/graphql": {
@@ -4035,20 +4047,20 @@
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.5.tgz",
-			"integrity": "sha512-cgwIRtKrpwhLoBi0CUNuY83DPGRMaWVjqVI/bGKsLJ4PzyWZNaEmhHroI2xlrVXkk6nFv0IsZpOp+ZWSWUS2AQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+			"integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^13.6.0"
+				"@octokit/types": "^13.10.0"
 			},
 			"engines": {
 				"node": ">= 18"
@@ -4093,15 +4105,16 @@
 			}
 		},
 		"node_modules/@octokit/request": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
-			"integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
+			"version": "9.2.4",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+			"integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/endpoint": "^10.0.0",
-				"@octokit/request-error": "^6.0.1",
-				"@octokit/types": "^13.1.0",
+				"@octokit/endpoint": "^10.1.4",
+				"@octokit/request-error": "^6.1.8",
+				"@octokit/types": "^14.0.0",
+				"fast-content-type-parse": "^2.0.0",
 				"universal-user-agent": "^7.0.2"
 			},
 			"engines": {
@@ -4109,26 +4122,60 @@
 			}
 		},
 		"node_modules/@octokit/request-error": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.5.tgz",
-			"integrity": "sha512-IlBTfGX8Yn/oFPMwSfvugfncK2EwRLjzbrpifNaMY8o/HTEAFqCA1FZxjD9cWvSKBHgrIhc4CSBIzMxiLsbzFQ==",
+			"version": "6.1.8",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+			"integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^13.0.0"
+				"@octokit/types": "^14.0.0"
 			},
 			"engines": {
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/types": {
-			"version": "13.6.1",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.1.tgz",
-			"integrity": "sha512-PHZE9Z+kWXb23Ndik8MKPirBPziOc0D2/3KH1P+6jK5nGWe96kadZuE4jev2/Jq7FvIfTlT2Ltg8Fv2x1v0a5g==",
+		"node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+			"version": "25.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+			"integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/types": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+			"integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
+				"@octokit/openapi-types": "^25.1.0"
+			}
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+			"version": "25.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+			"integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/types": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+			"integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^25.1.0"
+			}
+		},
+		"node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -5596,9 +5643,9 @@
 			}
 		},
 		"node_modules/@storybook/nextjs/node_modules/postcss": {
-			"version": "8.4.47",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-			"integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+			"version": "8.5.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+			"integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
 			"dev": true,
 			"funding": [
 				{
@@ -5616,8 +5663,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.7",
-				"picocolors": "^1.1.0",
+				"nanoid": "^3.3.16",
+				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
 			"engines": {
@@ -6522,13 +6569,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -6610,9 +6657,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7071,73 +7118,73 @@
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-			"integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+			"integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/helper-numbers": "1.11.6",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+				"@webassemblyjs/helper-numbers": "1.13.2",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2"
 			}
 		},
 		"node_modules/@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.11.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-			"integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+			"integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
 			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
-			"version": "1.11.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-			"integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+			"integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
 			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-			"integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+			"integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
 			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
-			"version": "1.11.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-			"integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+			"integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/floating-point-hex-parser": "1.11.6",
-				"@webassemblyjs/helper-api-error": "1.11.6",
+				"@webassemblyjs/floating-point-hex-parser": "1.13.2",
+				"@webassemblyjs/helper-api-error": "1.13.2",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"node_modules/@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.11.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-			"integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+			"integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
 			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-			"integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+			"integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.12.1",
-				"@webassemblyjs/helper-buffer": "1.12.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-				"@webassemblyjs/wasm-gen": "1.12.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/wasm-gen": "1.14.1"
 			}
 		},
 		"node_modules/@webassemblyjs/ieee754": {
-			"version": "1.11.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-			"integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+			"integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7145,9 +7192,9 @@
 			}
 		},
 		"node_modules/@webassemblyjs/leb128": {
-			"version": "1.11.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-			"integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+			"integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -7155,79 +7202,79 @@
 			}
 		},
 		"node_modules/@webassemblyjs/utf8": {
-			"version": "1.11.6",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-			"integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+			"integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
 			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-			"integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+			"integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.12.1",
-				"@webassemblyjs/helper-buffer": "1.12.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-				"@webassemblyjs/helper-wasm-section": "1.12.1",
-				"@webassemblyjs/wasm-gen": "1.12.1",
-				"@webassemblyjs/wasm-opt": "1.12.1",
-				"@webassemblyjs/wasm-parser": "1.12.1",
-				"@webassemblyjs/wast-printer": "1.12.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/helper-wasm-section": "1.14.1",
+				"@webassemblyjs/wasm-gen": "1.14.1",
+				"@webassemblyjs/wasm-opt": "1.14.1",
+				"@webassemblyjs/wasm-parser": "1.14.1",
+				"@webassemblyjs/wast-printer": "1.14.1"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-gen": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-			"integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+			"integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.12.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-				"@webassemblyjs/ieee754": "1.11.6",
-				"@webassemblyjs/leb128": "1.11.6",
-				"@webassemblyjs/utf8": "1.11.6"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/ieee754": "1.13.2",
+				"@webassemblyjs/leb128": "1.13.2",
+				"@webassemblyjs/utf8": "1.13.2"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-opt": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-			"integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+			"integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.12.1",
-				"@webassemblyjs/helper-buffer": "1.12.1",
-				"@webassemblyjs/wasm-gen": "1.12.1",
-				"@webassemblyjs/wasm-parser": "1.12.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/wasm-gen": "1.14.1",
+				"@webassemblyjs/wasm-parser": "1.14.1"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-parser": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-			"integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+			"integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.12.1",
-				"@webassemblyjs/helper-api-error": "1.11.6",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-				"@webassemblyjs/ieee754": "1.11.6",
-				"@webassemblyjs/leb128": "1.11.6",
-				"@webassemblyjs/utf8": "1.11.6"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-api-error": "1.13.2",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/ieee754": "1.13.2",
+				"@webassemblyjs/leb128": "1.13.2",
+				"@webassemblyjs/utf8": "1.13.2"
 			}
 		},
 		"node_modules/@webassemblyjs/wast-printer": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-			"integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+			"integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.12.1",
+				"@webassemblyjs/ast": "1.14.1",
 				"@xtuc/long": "4.2.2"
 			}
 		},
@@ -7360,10 +7407,10 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"devOptional": true,
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -7380,7 +7427,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
 			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.0.0"
@@ -7395,10 +7442,10 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-			"dev": true,
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -7415,14 +7462,14 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/ajv-keywords": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"ajv": "^6.9.1"
@@ -7811,9 +7858,9 @@
 			}
 		},
 		"node_modules/asn1.js/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.5",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+			"integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -7996,23 +8043,54 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-			"integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+			"integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
+				"follow-redirects": "^1.16.0",
+				"form-data": "^4.0.5",
+				"https-proxy-agent": "^5.0.1",
+				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/axios/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/axios/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/axios/node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
@@ -8253,6 +8331,19 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz",
+			"integrity": "sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -8321,31 +8412,31 @@
 			"license": "MIT"
 		},
 		"node_modules/bn.js": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-			"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+			"integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.3",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-			"integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+			"version": "1.20.6",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+			"integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"bytes": "3.1.2",
+				"bytes": "~3.1.2",
 				"content-type": "~1.0.5",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.13.0",
-				"raw-body": "2.5.2",
+				"destroy": "~1.2.0",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"on-finished": "~2.4.1",
+				"qs": "~6.15.1",
+				"raw-body": "~2.5.3",
 				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
+				"unpipe": "~1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.8",
@@ -8362,12 +8453,43 @@
 				"ms": "2.0.0"
 			}
 		},
+		"node_modules/body-parser/node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/body-parser/node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/body-parser/node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
@@ -8555,9 +8677,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
-			"integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
+			"version": "4.28.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+			"integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
 			"devOptional": true,
 			"funding": [
 				{
@@ -8575,10 +8697,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001663",
-				"electron-to-chromium": "^1.5.28",
-				"node-releases": "^2.0.18",
-				"update-browserslist-db": "^1.1.0"
+				"baseline-browser-mapping": "^2.10.44",
+				"caniuse-lite": "^1.0.30001806",
+				"electron-to-chromium": "^1.5.393",
+				"node-releases": "^2.0.51",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -8675,17 +8798,47 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"es-define-property": "^1.0.0",
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
 				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.4",
-				"set-function-length": "^1.2.1"
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8726,9 +8879,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001669",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
-			"integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==",
+			"version": "1.0.30001806",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+			"integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -8963,14 +9116,18 @@
 			}
 		},
 		"node_modules/cipher-base": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+			"integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "^2.0.4",
+				"safe-buffer": "^5.2.1",
+				"to-buffer": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/cjs-module-lexer": {
@@ -9683,9 +9840,9 @@
 			}
 		},
 		"node_modules/create-ecdh/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.5",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+			"integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -9719,9 +9876,9 @@
 			}
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10369,9 +10526,9 @@
 			}
 		},
 		"node_modules/diffie-hellman/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.5",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+			"integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10521,6 +10678,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/duplexer": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -10603,16 +10775,16 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.40",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.40.tgz",
-			"integrity": "sha512-LYm78o6if4zTasnYclgQzxEcgMoIcybWOhkATWepN95uwVVWV0/IW10v+2sIeHE+bIYWipLneTftVyQm45UY7g==",
+			"version": "1.5.396",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+			"integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
 			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/elliptic": {
-			"version": "6.5.7",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-			"integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+			"version": "6.6.1",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+			"integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10626,9 +10798,9 @@
 			}
 		},
 		"node_modules/elliptic/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.5",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+			"integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10699,14 +10871,14 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.17.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+			"version": "5.24.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+			"integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.3.3"
 			},
 			"engines": {
 				"node": ">=10.13.0"
@@ -11012,14 +11184,11 @@
 			}
 		},
 		"node_modules/es-define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"get-intrinsic": "^1.2.4"
-			},
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -11085,13 +11254,13 @@
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
 			"integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11102,15 +11271,16 @@
 			}
 		},
 		"node_modules/es-set-tostringtag": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"get-intrinsic": "^1.2.4",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
 				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.1"
+				"hasown": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -11552,9 +11722,9 @@
 			}
 		},
 		"node_modules/eslint-config-next/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11598,13 +11768,13 @@
 			}
 		},
 		"node_modules/eslint-config-next/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -12356,46 +12526,50 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.21.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-			"integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+			"integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.20.3",
-				"content-disposition": "0.5.4",
+				"body-parser": "~1.20.5",
+				"content-disposition": "~0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.7.1",
-				"cookie-signature": "1.0.6",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.3.1",
-				"fresh": "0.5.2",
-				"http-errors": "2.0.0",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
 				"merge-descriptors": "1.0.3",
 				"methods": "~1.1.2",
-				"on-finished": "2.4.1",
+				"on-finished": "~2.4.1",
 				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.10",
+				"path-to-regexp": "~0.1.12",
 				"proxy-addr": "~2.0.7",
-				"qs": "6.13.0",
+				"qs": "~6.15.1",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
-				"send": "0.19.0",
-				"serve-static": "1.16.2",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
 				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
+				"statuses": "~2.0.1",
 				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
 			},
 			"engines": {
 				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/express/node_modules/cookie": {
@@ -12462,6 +12636,23 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/fast-content-type-parse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+			"integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -12510,7 +12701,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-levenshtein": {
@@ -12521,10 +12712,20 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-			"integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
-			"dev": true,
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"devOptional": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastq": {
@@ -12765,16 +12966,16 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+			"integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
 			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"dev": true,
 			"funding": [
 				{
@@ -12793,23 +12994,29 @@
 			}
 		},
 		"node_modules/for-each": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-callable": "^1.1.3"
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/foreground-child": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"cross-spawn": "^7.0.0",
+				"cross-spawn": "^7.0.6",
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {
@@ -12962,15 +13169,17 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-			"integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -13210,23 +13419,42 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
 				"function-bind": "^1.1.2",
-				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3",
-				"hasown": "^2.0.0"
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/get-stream": {
@@ -13382,17 +13610,10 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/glob-to-regexp": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"devOptional": true,
-			"license": "BSD-2-Clause"
-		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13400,13 +13621,13 @@
 			}
 		},
 		"node_modules/glob/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -13506,13 +13727,13 @@
 			}
 		},
 		"node_modules/gopd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"get-intrinsic": "^1.1.3"
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -13572,9 +13793,9 @@
 			}
 		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13650,9 +13871,9 @@
 			}
 		},
 		"node_modules/has-symbols": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13704,9 +13925,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14211,9 +14432,9 @@
 			"dev": true
 		},
 		"node_modules/image-size": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/image-size/-/image-size-1.1.1.tgz",
-			"integrity": "sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+			"integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14929,13 +15150,13 @@
 			}
 		},
 		"node_modules/is-typed-array": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"which-typed-array": "^1.1.14"
+				"which-typed-array": "^1.1.16"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -15156,9 +15377,9 @@
 			}
 		},
 		"node_modules/joi": {
-			"version": "17.13.3",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-			"integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+			"version": "17.13.4",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+			"integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -15176,10 +15397,20 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -15236,7 +15467,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/json-schema": {
@@ -15250,7 +15481,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
@@ -15561,16 +15792,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/loader-runner": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
-			"devOptional": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.11.5"
-			}
-		},
 		"node_modules/loader-utils": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
@@ -15598,16 +15819,16 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16080,6 +16301,16 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -16208,9 +16439,9 @@
 			}
 		},
 		"node_modules/mdast-util-to-hast": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-			"integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+			"integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0",
@@ -17013,9 +17244,9 @@
 			}
 		},
 		"node_modules/miller-rabin/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.5",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+			"integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -17036,7 +17267,7 @@
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -17046,7 +17277,7 @@
 			"version": "2.1.35",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mime-db": "1.52.0"
@@ -17090,9 +17321,9 @@
 			"license": "MIT"
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -17110,6 +17341,67 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minimizer-webpack-plugin": {
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+			"integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jest-worker": "^27.4.5",
+				"schema-utils": "^4.3.0",
+				"terser": "^5.31.1"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@minify-html/node": {
+					"optional": true
+				},
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/css": {
+					"optional": true
+				},
+				"@swc/html": {
+					"optional": true
+				},
+				"clean-css": {
+					"optional": true
+				},
+				"cssnano": {
+					"optional": true
+				},
+				"csso": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"html-minifier-terser": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"uglify-js": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/minipass": {
@@ -17150,9 +17442,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.7",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -17199,12 +17491,12 @@
 			"license": "MIT"
 		},
 		"node_modules/next": {
-			"version": "14.2.13",
-			"resolved": "https://registry.npmjs.org/next/-/next-14.2.13.tgz",
-			"integrity": "sha512-BseY9YNw8QJSwLYD7hlZzl6QVDoSFHL/URN5K64kVEVpCsSOWeyjbIGK+dZUaRViHTaMQX8aqmnn0PHBbGZezg==",
+			"version": "14.2.35",
+			"resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+			"integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "14.2.13",
+				"@next/env": "14.2.35",
 				"@swc/helpers": "0.5.5",
 				"busboy": "1.6.0",
 				"caniuse-lite": "^1.0.30001579",
@@ -17219,15 +17511,15 @@
 				"node": ">=18.17.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "14.2.13",
-				"@next/swc-darwin-x64": "14.2.13",
-				"@next/swc-linux-arm64-gnu": "14.2.13",
-				"@next/swc-linux-arm64-musl": "14.2.13",
-				"@next/swc-linux-x64-gnu": "14.2.13",
-				"@next/swc-linux-x64-musl": "14.2.13",
-				"@next/swc-win32-arm64-msvc": "14.2.13",
-				"@next/swc-win32-ia32-msvc": "14.2.13",
-				"@next/swc-win32-x64-msvc": "14.2.13"
+				"@next/swc-darwin-arm64": "14.2.33",
+				"@next/swc-darwin-x64": "14.2.33",
+				"@next/swc-linux-arm64-gnu": "14.2.33",
+				"@next/swc-linux-arm64-musl": "14.2.33",
+				"@next/swc-linux-x64-gnu": "14.2.33",
+				"@next/swc-linux-x64-musl": "14.2.33",
+				"@next/swc-win32-arm64-msvc": "14.2.33",
+				"@next/swc-win32-ia32-msvc": "14.2.33",
+				"@next/swc-win32-x64-msvc": "14.2.33"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",
@@ -17415,11 +17707,14 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.18",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+			"version": "2.0.51",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+			"integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
 			"devOptional": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/normalize-package-data": {
 			"version": "6.0.2",
@@ -17490,9 +17785,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "10.9.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-10.9.0.tgz",
-			"integrity": "sha512-ZanDioFylI9helNhl2LNd+ErmVD+H5I53ry41ixlLyCBgkuYb+58CvbAp99hW+zr5L9W4X7CchSoeqKdngOLSw==",
+			"version": "10.9.8",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-10.9.8.tgz",
+			"integrity": "sha512-fYwb6ODSmHkqrJQQaCxY3M2lPf/mpgC7ik0HSzzIwG5CGtabRp4bNqikatvCoT42b5INQSqudVH0R7yVmC9hVg==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -17574,71 +17869,71 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^8.0.0",
+				"@npmcli/arborist": "^8.0.5",
 				"@npmcli/config": "^9.0.0",
 				"@npmcli/fs": "^4.0.0",
-				"@npmcli/map-workspaces": "^4.0.1",
-				"@npmcli/package-json": "^6.0.1",
-				"@npmcli/promise-spawn": "^8.0.1",
-				"@npmcli/redact": "^3.0.0",
-				"@npmcli/run-script": "^9.0.1",
-				"@sigstore/tuf": "^2.3.4",
-				"abbrev": "^3.0.0",
+				"@npmcli/map-workspaces": "^4.0.2",
+				"@npmcli/package-json": "^6.2.0",
+				"@npmcli/promise-spawn": "^8.0.3",
+				"@npmcli/redact": "^3.2.2",
+				"@npmcli/run-script": "^9.1.0",
+				"@sigstore/tuf": "^3.1.1",
+				"abbrev": "^3.0.1",
 				"archy": "~1.0.0",
 				"cacache": "^19.0.1",
-				"chalk": "^5.3.0",
-				"ci-info": "^4.0.0",
+				"chalk": "^5.6.2",
+				"ci-info": "^4.4.0",
 				"cli-columns": "^4.0.0",
 				"fastest-levenshtein": "^1.0.16",
 				"fs-minipass": "^3.0.3",
-				"glob": "^10.4.5",
+				"glob": "^10.5.0",
 				"graceful-fs": "^4.2.11",
-				"hosted-git-info": "^8.0.0",
+				"hosted-git-info": "^8.1.0",
 				"ini": "^5.0.0",
-				"init-package-json": "^7.0.1",
-				"is-cidr": "^5.1.0",
+				"init-package-json": "^7.0.2",
+				"is-cidr": "^5.1.1",
 				"json-parse-even-better-errors": "^4.0.0",
 				"libnpmaccess": "^9.0.0",
-				"libnpmdiff": "^7.0.0",
-				"libnpmexec": "^9.0.0",
-				"libnpmfund": "^6.0.0",
+				"libnpmdiff": "^7.0.5",
+				"libnpmexec": "^9.0.5",
+				"libnpmfund": "^6.0.5",
 				"libnpmhook": "^11.0.0",
 				"libnpmorg": "^7.0.0",
-				"libnpmpack": "^8.0.0",
-				"libnpmpublish": "^10.0.0",
+				"libnpmpack": "^8.0.5",
+				"libnpmpublish": "^10.0.2",
 				"libnpmsearch": "^8.0.0",
 				"libnpmteam": "^7.0.0",
 				"libnpmversion": "^7.0.0",
-				"make-fetch-happen": "^14.0.1",
-				"minimatch": "^9.0.5",
-				"minipass": "^7.1.1",
+				"make-fetch-happen": "^14.0.3",
+				"minimatch": "^9.0.9",
+				"minipass": "^7.1.3",
 				"minipass-pipeline": "^1.2.4",
 				"ms": "^2.1.2",
-				"node-gyp": "^10.2.0",
-				"nopt": "^8.0.0",
-				"normalize-package-data": "^7.0.0",
+				"node-gyp": "^11.5.0",
+				"nopt": "^8.1.0",
+				"normalize-package-data": "^7.0.1",
 				"npm-audit-report": "^6.0.0",
-				"npm-install-checks": "^7.1.0",
-				"npm-package-arg": "^12.0.0",
+				"npm-install-checks": "^7.1.2",
+				"npm-package-arg": "^12.0.2",
 				"npm-pick-manifest": "^10.0.0",
 				"npm-profile": "^11.0.1",
-				"npm-registry-fetch": "^18.0.1",
+				"npm-registry-fetch": "^18.0.2",
 				"npm-user-validate": "^3.0.0",
-				"p-map": "^4.0.0",
-				"pacote": "^19.0.0",
+				"p-map": "^7.0.4",
+				"pacote": "^19.0.1",
 				"parse-conflict-json": "^4.0.0",
 				"proc-log": "^5.0.0",
 				"qrcode-terminal": "^0.12.0",
-				"read": "^4.0.0",
-				"semver": "^7.6.3",
+				"read": "^4.1.0",
+				"semver": "^7.7.4",
 				"spdx-expression-parse": "^4.0.0",
 				"ssri": "^12.0.0",
 				"supports-color": "^9.4.0",
-				"tar": "^6.2.1",
+				"tar": "^7.5.11",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^1.3.0",
 				"treeverse": "^3.0.0",
-				"validate-npm-package-name": "^6.0.0",
+				"validate-npm-package-name": "^6.0.2",
 				"which": "^5.0.0",
 				"write-file-atomic": "^6.0.0"
 			},
@@ -17681,7 +17976,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-			"version": "6.0.1",
+			"version": "6.2.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -17716,12 +18011,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-			"version": "7.1.0",
+			"version": "7.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -17765,7 +18060,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "8.0.0",
+			"version": "8.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -17800,6 +18095,7 @@
 				"proggy": "^3.0.0",
 				"promise-all-reject-late": "^1.0.0",
 				"promise-call-limit": "^3.0.1",
+				"promise-retry": "^2.0.1",
 				"read-package-json-fast": "^4.0.0",
 				"semver": "^7.3.7",
 				"ssri": "^12.0.0",
@@ -17845,7 +18141,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
-			"version": "6.0.1",
+			"version": "6.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -17855,7 +18151,6 @@
 				"lru-cache": "^10.0.1",
 				"npm-pick-manifest": "^10.0.0",
 				"proc-log": "^5.0.0",
-				"promise-inflight": "^1.0.1",
 				"promise-retry": "^2.0.1",
 				"semver": "^7.3.5",
 				"which": "^5.0.0"
@@ -17881,7 +18176,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
-			"version": "4.0.1",
+			"version": "4.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -17896,16 +18191,47 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-			"version": "8.0.0",
+			"version": "8.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"cacache": "^19.0.0",
 				"json-parse-even-better-errors": "^4.0.0",
-				"pacote": "^19.0.0",
+				"pacote": "^20.0.0",
 				"proc-log": "^5.0.0",
 				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
+			"version": "20.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^6.0.0",
+				"@npmcli/installed-package-contents": "^3.0.0",
+				"@npmcli/package-json": "^6.0.0",
+				"@npmcli/promise-spawn": "^8.0.0",
+				"@npmcli/run-script": "^9.0.0",
+				"cacache": "^19.0.0",
+				"fs-minipass": "^3.0.0",
+				"minipass": "^7.0.2",
+				"npm-package-arg": "^12.0.0",
+				"npm-packlist": "^9.0.0",
+				"npm-pick-manifest": "^10.0.0",
+				"npm-registry-fetch": "^18.0.0",
+				"proc-log": "^5.0.0",
+				"promise-retry": "^2.0.1",
+				"sigstore": "^3.0.0",
+				"ssri": "^12.0.0",
+				"tar": "^7.5.10"
+			},
+			"bin": {
+				"pacote": "bin/index.js"
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
@@ -17930,7 +18256,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/package-json": {
-			"version": "6.0.1",
+			"version": "6.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -17939,16 +18265,16 @@
 				"glob": "^10.2.2",
 				"hosted-git-info": "^8.0.0",
 				"json-parse-even-better-errors": "^4.0.0",
-				"normalize-package-data": "^7.0.0",
 				"proc-log": "^5.0.0",
-				"semver": "^7.5.3"
+				"semver": "^7.5.3",
+				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
-			"version": "8.0.1",
+			"version": "8.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -17960,19 +18286,19 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/query": {
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"postcss-selector-parser": "^6.1.2"
+				"postcss-selector-parser": "^7.0.0"
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/redact": {
-			"version": "3.0.0",
+			"version": "3.2.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -17981,7 +18307,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "9.0.1",
+			"version": "9.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -17989,7 +18315,7 @@
 				"@npmcli/node-gyp": "^4.0.0",
 				"@npmcli/package-json": "^6.0.0",
 				"@npmcli/promise-spawn": "^8.0.0",
-				"node-gyp": "^10.0.0",
+				"node-gyp": "^11.0.0",
 				"proc-log": "^5.0.0",
 				"which": "^5.0.0"
 			},
@@ -18008,213 +18334,77 @@
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/bundle": {
-			"version": "2.3.2",
+			"version": "3.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.3.2"
+				"@sigstore/protobuf-specs": "^0.4.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/core": {
-			"version": "1.1.0",
+			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-			"version": "0.3.2",
+			"version": "0.4.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/sign": {
-			"version": "2.3.2",
+			"version": "3.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.0.0",
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"make-fetch-happen": "^13.0.1",
-				"proc-log": "^4.2.0",
+				"@sigstore/bundle": "^3.1.0",
+				"@sigstore/core": "^2.0.0",
+				"@sigstore/protobuf-specs": "^0.4.0",
+				"make-fetch-happen": "^14.0.2",
+				"proc-log": "^5.0.0",
 				"promise-retry": "^2.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/sign/node_modules/@npmcli/agent": {
-			"version": "2.2.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^10.0.1",
-				"socks-proxy-agent": "^8.0.3"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/sign/node_modules/@npmcli/fs": {
-			"version": "3.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/sign/node_modules/cacache": {
-			"version": "18.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/fs": "^3.1.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^10.0.1",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^2.0.1",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^4.0.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11",
-				"unique-filename": "^3.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/sign/node_modules/make-fetch-happen": {
-			"version": "13.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/agent": "^2.0.0",
-				"cacache": "^18.0.0",
-				"http-cache-semantics": "^4.1.1",
-				"is-lambda": "^1.0.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^3.0.0",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^0.6.3",
-				"proc-log": "^4.2.0",
-				"promise-retry": "^2.0.1",
-				"ssri": "^10.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/sign/node_modules/minipass-fetch": {
-			"version": "3.0.5",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.3",
-				"minipass-sized": "^1.0.3",
-				"minizlib": "^2.1.2"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			},
-			"optionalDependencies": {
-				"encoding": "^0.1.13"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/sign/node_modules/proc-log": {
-			"version": "4.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/sign/node_modules/ssri": {
-			"version": "10.0.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/sign/node_modules/unique-filename": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"unique-slug": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/sign/node_modules/unique-slug": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/tuf": {
-			"version": "2.3.4",
+			"version": "3.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"tuf-js": "^2.2.1"
+				"@sigstore/protobuf-specs": "^0.4.1",
+				"tuf-js": "^3.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/verify": {
-			"version": "1.2.1",
+			"version": "2.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.1.0",
-				"@sigstore/protobuf-specs": "^0.3.2"
+				"@sigstore/bundle": "^3.1.0",
+				"@sigstore/core": "^2.0.0",
+				"@sigstore/protobuf-specs": "^0.4.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@tufjs/canonical-json": {
@@ -18226,21 +18416,8 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/@tufjs/models": {
-			"version": "2.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tufjs/canonical-json": "2.0.0",
-				"minimatch": "^9.0.4"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
 		"node_modules/npm/node_modules/abbrev": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -18249,28 +18426,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/agent-base": {
-			"version": "7.1.1",
+			"version": "7.1.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/npm/node_modules/aggregate-error": {
-			"version": "3.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/ansi-regex": {
@@ -18283,7 +18444,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/ansi-styles": {
-			"version": "6.2.1",
+			"version": "6.2.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -18295,7 +18456,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/aproba": {
-			"version": "2.0.0",
+			"version": "2.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
@@ -18341,7 +18502,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/brace-expansion": {
-			"version": "2.0.1",
+			"version": "2.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -18372,83 +18533,8 @@
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/npm/node_modules/cacache/node_modules/chownr": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/minizlib": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.4",
-				"rimraf": "^5.0.5"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/p-map": {
-			"version": "7.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/tar": {
-			"version": "7.4.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.0.1",
-				"mkdirp": "^3.0.1",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/yallist": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/npm/node_modules/chalk": {
-			"version": "5.3.0",
+			"version": "5.6.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -18460,16 +18546,16 @@
 			}
 		},
 		"node_modules/npm/node_modules/chownr": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/npm/node_modules/ci-info": {
-			"version": "4.0.0",
+			"version": "4.4.0",
 			"dev": true,
 			"funding": [
 				{
@@ -18484,7 +18570,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/cidr-regex": {
-			"version": "4.1.1",
+			"version": "4.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
@@ -18493,15 +18579,6 @@
 			},
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"node_modules/npm/node_modules/clean-stack": {
-			"version": "2.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/npm/node_modules/cli-columns": {
@@ -18551,7 +18628,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/cross-spawn": {
-			"version": "7.0.3",
+			"version": "7.0.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -18592,12 +18669,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/debug": {
-			"version": "4.3.6",
+			"version": "4.4.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -18608,14 +18685,8 @@
 				}
 			}
 		},
-		"node_modules/npm/node_modules/debug/node_modules/ms": {
-			"version": "2.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
 		"node_modules/npm/node_modules/diff": {
-			"version": "5.2.0",
+			"version": "5.2.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-3-Clause",
@@ -18661,7 +18732,7 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/exponential-backoff": {
-			"version": "3.1.1",
+			"version": "3.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0"
@@ -18675,13 +18746,30 @@
 				"node": ">= 4.9.1"
 			}
 		},
+		"node_modules/npm/node_modules/fdir": {
+			"version": "6.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/npm/node_modules/foreground-child": {
-			"version": "3.3.0",
+			"version": "3.3.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"cross-spawn": "^7.0.0",
+				"cross-spawn": "^7.0.6",
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {
@@ -18704,7 +18792,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/glob": {
-			"version": "10.4.5",
+			"version": "10.5.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -18730,7 +18818,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/hosted-git-info": {
-			"version": "8.0.0",
+			"version": "8.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -18742,7 +18830,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/http-cache-semantics": {
-			"version": "4.1.1",
+			"version": "4.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause"
@@ -18761,12 +18849,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/https-proxy-agent": {
-			"version": "7.0.5",
+			"version": "7.0.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "^7.0.2",
+				"agent-base": "^7.1.2",
 				"debug": "4"
 			},
 			"engines": {
@@ -18807,15 +18895,6 @@
 				"node": ">=0.8.19"
 			}
 		},
-		"node_modules/npm/node_modules/indent-string": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/npm/node_modules/ini": {
 			"version": "5.0.0",
 			"dev": true,
@@ -18826,7 +18905,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/init-package-json": {
-			"version": "7.0.1",
+			"version": "7.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -18844,14 +18923,10 @@
 			}
 		},
 		"node_modules/npm/node_modules/ip-address": {
-			"version": "9.0.5",
+			"version": "10.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"sprintf-js": "^1.1.3"
-			},
 			"engines": {
 				"node": ">= 12"
 			}
@@ -18869,7 +18944,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/is-cidr": {
-			"version": "5.1.0",
+			"version": "5.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
@@ -18888,12 +18963,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/npm/node_modules/is-lambda": {
-			"version": "1.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/isexe": {
 			"version": "2.0.0",
@@ -18915,12 +18984,6 @@
 			"optionalDependencies": {
 				"@pkgjs/parseargs": "^0.11.0"
 			}
-		},
-		"node_modules/npm/node_modules/jsbn": {
-			"version": "1.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/json-parse-even-better-errors": {
 			"version": "4.0.0",
@@ -18975,31 +19038,31 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "7.0.0",
+			"version": "7.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.0",
+				"@npmcli/arborist": "^8.0.5",
 				"@npmcli/installed-package-contents": "^3.0.0",
 				"binary-extensions": "^2.3.0",
 				"diff": "^5.1.0",
 				"minimatch": "^9.0.4",
 				"npm-package-arg": "^12.0.0",
 				"pacote": "^19.0.0",
-				"tar": "^6.2.1"
+				"tar": "^7.5.11"
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "9.0.0",
+			"version": "9.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.0",
+				"@npmcli/arborist": "^8.0.5",
 				"@npmcli/run-script": "^9.0.1",
 				"ci-info": "^4.0.0",
 				"npm-package-arg": "^12.0.0",
@@ -19015,12 +19078,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "6.0.0",
+			"version": "6.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.0"
+				"@npmcli/arborist": "^8.0.5"
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
@@ -19053,12 +19116,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "8.0.0",
+			"version": "8.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.0",
+				"@npmcli/arborist": "^8.0.5",
 				"@npmcli/run-script": "^9.0.1",
 				"npm-package-arg": "^12.0.0",
 				"pacote": "^19.0.0"
@@ -19068,7 +19131,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "10.0.0",
+			"version": "10.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -19079,7 +19142,7 @@
 				"npm-registry-fetch": "^18.0.1",
 				"proc-log": "^5.0.0",
 				"semver": "^7.3.7",
-				"sigstore": "^2.2.0",
+				"sigstore": "^3.0.0",
 				"ssri": "^12.0.0"
 			},
 			"engines": {
@@ -19134,7 +19197,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "14.0.1",
+			"version": "14.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -19146,7 +19209,7 @@
 				"minipass-fetch": "^4.0.0",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^0.6.3",
+				"negotiator": "^1.0.0",
 				"proc-log": "^5.0.0",
 				"promise-retry": "^2.0.1",
 				"ssri": "^12.0.0"
@@ -19156,12 +19219,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/minimatch": {
-			"version": "9.0.5",
+			"version": "9.0.9",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -19171,10 +19234,10 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass": {
-			"version": "7.1.2",
+			"version": "7.1.3",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
@@ -19192,7 +19255,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -19206,19 +19269,6 @@
 			},
 			"optionalDependencies": {
 				"encoding": "^0.1.13"
-			}
-		},
-		"node_modules/npm/node_modules/minipass-fetch/node_modules/minizlib": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.4",
-				"rimraf": "^5.0.5"
-			},
-			"engines": {
-				"node": ">= 18"
 			}
 		},
 		"node_modules/npm/node_modules/minipass-flush": {
@@ -19245,6 +19295,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
 		"node_modules/npm/node_modules/minipass-pipeline": {
 			"version": "1.2.4",
 			"dev": true,
@@ -19268,6 +19324,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/minipass-sized": {
 			"version": "1.0.3",
@@ -19293,41 +19355,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/npm/node_modules/minipass-sized/node_modules/yallist": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
 		"node_modules/npm/node_modules/minizlib": {
-			"version": "2.1.2",
+			"version": "3.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
+				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/npm/node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/mkdirp": {
-			"version": "1.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/npm/node_modules/ms": {
@@ -19346,7 +19389,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/negotiator": {
-			"version": "0.6.3",
+			"version": "1.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -19355,220 +19398,36 @@
 			}
 		},
 		"node_modules/npm/node_modules/node-gyp": {
-			"version": "10.2.0",
+			"version": "11.5.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.0",
 				"exponential-backoff": "^3.1.1",
-				"glob": "^10.3.10",
 				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^13.0.0",
-				"nopt": "^7.0.0",
-				"proc-log": "^4.1.0",
+				"make-fetch-happen": "^14.0.3",
+				"nopt": "^8.0.0",
+				"proc-log": "^5.0.0",
 				"semver": "^7.3.5",
-				"tar": "^6.2.1",
-				"which": "^4.0.0"
+				"tar": "^7.4.3",
+				"tinyglobby": "^0.2.12",
+				"which": "^5.0.0"
 			},
 			"bin": {
 				"node-gyp": "bin/node-gyp.js"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/agent": {
-			"version": "2.2.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^10.0.1",
-				"socks-proxy-agent": "^8.0.3"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/fs": {
-			"version": "3.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
-			"version": "18.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/fs": "^3.1.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^10.0.1",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^2.0.1",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^4.0.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11",
-				"unique-filename": "^3.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/isexe": {
-			"version": "3.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
-			"version": "13.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/agent": "^2.0.0",
-				"cacache": "^18.0.0",
-				"http-cache-semantics": "^4.1.1",
-				"is-lambda": "^1.0.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^3.0.0",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^0.6.3",
-				"proc-log": "^4.2.0",
-				"promise-retry": "^2.0.1",
-				"ssri": "^10.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/minipass-fetch": {
-			"version": "3.0.5",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.3",
-				"minipass-sized": "^1.0.3",
-				"minizlib": "^2.1.2"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			},
-			"optionalDependencies": {
-				"encoding": "^0.1.13"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
-			"version": "7.2.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"abbrev": "^2.0.0"
-			},
-			"bin": {
-				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/proc-log": {
-			"version": "4.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
-			"version": "10.0.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"unique-slug": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/which": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^3.1.1"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/nopt": {
-			"version": "8.0.0",
+			"version": "8.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"abbrev": "^2.0.0"
+				"abbrev": "^3.0.0"
 			},
 			"bin": {
 				"nopt": "bin/nopt.js"
@@ -19577,17 +19436,8 @@
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/npm/node_modules/nopt/node_modules/abbrev": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
 		"node_modules/npm/node_modules/normalize-package-data": {
-			"version": "7.0.0",
+			"version": "7.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
@@ -19622,7 +19472,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-install-checks": {
-			"version": "7.1.0",
+			"version": "7.1.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
@@ -19643,7 +19493,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-package-arg": {
-			"version": "12.0.0",
+			"version": "12.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -19698,7 +19548,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "18.0.1",
+			"version": "18.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -19716,19 +19566,6 @@
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/npm/node_modules/npm-registry-fetch/node_modules/minizlib": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.4",
-				"rimraf": "^5.0.5"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
 		"node_modules/npm/node_modules/npm-user-validate": {
 			"version": "3.0.0",
 			"dev": true,
@@ -19739,28 +19576,25 @@
 			}
 		},
 		"node_modules/npm/node_modules/p-map": {
-			"version": "4.0.0",
+			"version": "7.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"dependencies": {
-				"aggregate-error": "^3.0.0"
-			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/npm/node_modules/package-json-from-dist": {
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "19.0.0",
+			"version": "19.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -19779,9 +19613,9 @@
 				"npm-registry-fetch": "^18.0.0",
 				"proc-log": "^5.0.0",
 				"promise-retry": "^2.0.1",
-				"sigstore": "^2.2.0",
+				"sigstore": "^3.0.0",
 				"ssri": "^12.0.0",
-				"tar": "^6.1.11"
+				"tar": "^7.5.10"
 			},
 			"bin": {
 				"pacote": "bin/index.js"
@@ -19829,8 +19663,20 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/npm/node_modules/picomatch": {
+			"version": "4.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/npm/node_modules/postcss-selector-parser": {
-			"version": "6.1.2",
+			"version": "7.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -19870,19 +19716,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/promise-call-limit": {
-			"version": "3.0.1",
+			"version": "3.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
-		},
-		"node_modules/npm/node_modules/promise-inflight": {
-			"version": "1.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/promise-retry": {
 			"version": "2.0.1",
@@ -19918,7 +19758,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/read": {
-			"version": "4.0.0",
+			"version": "4.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -19960,21 +19800,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/npm/node_modules/rimraf": {
-			"version": "5.0.10",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^10.3.7"
-			},
-			"bin": {
-				"rimraf": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/npm/node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"dev": true,
@@ -19983,7 +19808,7 @@
 			"optional": true
 		},
 		"node_modules/npm/node_modules/semver": {
-			"version": "7.6.3",
+			"version": "7.7.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -20028,20 +19853,20 @@
 			}
 		},
 		"node_modules/npm/node_modules/sigstore": {
-			"version": "2.3.1",
+			"version": "3.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.0.0",
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"@sigstore/sign": "^2.3.2",
-				"@sigstore/tuf": "^2.3.4",
-				"@sigstore/verify": "^1.2.1"
+				"@sigstore/bundle": "^3.1.0",
+				"@sigstore/core": "^2.0.0",
+				"@sigstore/protobuf-specs": "^0.4.0",
+				"@sigstore/sign": "^3.1.0",
+				"@sigstore/tuf": "^3.1.0",
+				"@sigstore/verify": "^2.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/smart-buffer": {
@@ -20055,12 +19880,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks": {
-			"version": "2.8.3",
+			"version": "2.8.7",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ip-address": "^9.0.5",
+				"ip-address": "^10.0.1",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
@@ -20069,12 +19894,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks-proxy-agent": {
-			"version": "8.0.4",
+			"version": "8.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "^7.1.1",
+				"agent-base": "^7.1.2",
 				"debug": "^4.3.4",
 				"socks": "^2.8.3"
 			},
@@ -20119,16 +19944,10 @@
 			}
 		},
 		"node_modules/npm/node_modules/spdx-license-ids": {
-			"version": "3.0.18",
+			"version": "3.0.23",
 			"dev": true,
 			"inBundle": true,
 			"license": "CC0-1.0"
-		},
-		"node_modules/npm/node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/npm/node_modules/ssri": {
 			"version": "12.0.0",
@@ -20209,53 +20028,19 @@
 			}
 		},
 		"node_modules/npm/node_modules/tar": {
-			"version": "6.2.1",
+			"version": "7.5.11",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			}
 		},
 		"node_modules/npm/node_modules/text-table": {
@@ -20270,6 +20055,22 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
+		"node_modules/npm/node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
 		"node_modules/npm/node_modules/treeverse": {
 			"version": "3.0.0",
 			"dev": true,
@@ -20280,153 +20081,30 @@
 			}
 		},
 		"node_modules/npm/node_modules/tuf-js": {
-			"version": "2.2.1",
+			"version": "3.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tufjs/models": "2.0.1",
-				"debug": "^4.3.4",
-				"make-fetch-happen": "^13.0.1"
+				"@tufjs/models": "3.0.1",
+				"debug": "^4.4.1",
+				"make-fetch-happen": "^14.0.3"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/@npmcli/agent": {
-			"version": "2.2.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^10.0.1",
-				"socks-proxy-agent": "^8.0.3"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/@npmcli/fs": {
-			"version": "3.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/cacache": {
-			"version": "18.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/fs": "^3.1.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^10.0.1",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^2.0.1",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^4.0.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11",
-				"unique-filename": "^3.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/make-fetch-happen": {
-			"version": "13.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/agent": "^2.0.0",
-				"cacache": "^18.0.0",
-				"http-cache-semantics": "^4.1.1",
-				"is-lambda": "^1.0.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^3.0.0",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^0.6.3",
-				"proc-log": "^4.2.0",
-				"promise-retry": "^2.0.1",
-				"ssri": "^10.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/minipass-fetch": {
-			"version": "3.0.5",
+		"node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
+			"version": "3.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"minipass": "^7.0.3",
-				"minipass-sized": "^1.0.3",
-				"minizlib": "^2.1.2"
+				"@tufjs/canonical-json": "2.0.0",
+				"minimatch": "^9.0.5"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			},
-			"optionalDependencies": {
-				"encoding": "^0.1.13"
-			}
-		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/proc-log": {
-			"version": "4.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/ssri": {
-			"version": "10.0.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/unique-filename": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"unique-slug": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/unique-slug": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/unique-filename": {
@@ -20480,7 +20158,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/validate-npm-package-name": {
-			"version": "6.0.0",
+			"version": "6.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -20510,12 +20188,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/which/node_modules/isexe": {
-			"version": "3.1.1",
+			"version": "3.1.5",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/npm/node_modules/wrap-ansi": {
@@ -20569,7 +20247,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-			"version": "6.0.1",
+			"version": "6.2.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -20604,12 +20282,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-			"version": "7.1.0",
+			"version": "7.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -20632,10 +20310,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/yallist": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC"
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/nth-check": {
 			"version": "2.1.1",
@@ -20670,9 +20351,9 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-			"integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -21251,9 +20932,9 @@
 			"license": "ISC"
 		},
 		"node_modules/path-to-regexp": {
-			"version": "0.1.10",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-			"integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -21291,20 +20972,21 @@
 			}
 		},
 		"node_modules/pbkdf2": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-			"integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+			"integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"ripemd160": "^2.0.3",
+				"safe-buffer": "^5.2.1",
+				"sha.js": "^2.4.12",
+				"to-buffer": "^1.2.2"
 			},
 			"engines": {
-				"node": ">=0.12"
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/pend": {
@@ -21328,9 +21010,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -21669,16 +21351,19 @@
 			}
 		},
 		"node_modules/postcss-load-config/node_modules/yaml": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-			"integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/postcss-loader": {
@@ -22016,13 +21701,6 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/psl": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/public-encrypt": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -22039,9 +21717,9 @@
 			}
 		},
 		"node_modules/public-encrypt/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.5",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+			"integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -22060,20 +21738,21 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.0.6"
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -22090,13 +21769,6 @@
 			"engines": {
 				"node": ">=0.4.x"
 			}
-		},
-		"node_modules/querystringify": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/queue": {
 			"version": "6.0.2",
@@ -22133,7 +21805,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
@@ -22161,17 +21833,48 @@
 			}
 		},
 		"node_modules/raw-body": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+			"integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"unpipe": "~1.0.0"
 			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/raw-body/node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/raw-body/node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -22700,13 +22403,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/regenerator-transform": {
 			"version": "0.15.2",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
@@ -22960,7 +22656,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -22975,13 +22671,6 @@
 			"engines": {
 				"node": ">=0.10.5"
 			}
-		},
-		"node_modules/requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/resolve": {
 			"version": "1.22.8",
@@ -23122,26 +22811,50 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rimraf/node_modules/@isaacs/cliui": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+			"integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/rimraf/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/rimraf/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/rimraf/node_modules/glob": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
-			"integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+			"integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^4.0.1",
-				"minimatch": "^10.0.0",
+				"foreground-child": "^3.3.1",
+				"jackspeak": "^4.1.1",
+				"minimatch": "^10.1.1",
 				"minipass": "^7.1.2",
 				"package-json-from-dist": "^1.0.0",
 				"path-scurry": "^2.0.0"
@@ -23157,13 +22870,13 @@
 			}
 		},
 		"node_modules/rimraf/node_modules/jackspeak": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
-			"integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+			"integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
+				"@isaacs/cliui": "^9.0.0"
 			},
 			"engines": {
 				"node": "20 || >=22"
@@ -23183,16 +22896,16 @@
 			}
 		},
 		"node_modules/rimraf/node_modules/minimatch": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-			"integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -23216,15 +22929,81 @@
 			}
 		},
 		"node_modules/ripemd160": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+			"integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
+				"hash-base": "^3.1.2",
+				"inherits": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 0.8"
 			}
+		},
+		"node_modules/ripemd160/node_modules/hash-base": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+			"integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^2.3.8",
+				"safe-buffer": "^5.2.1",
+				"to-buffer": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/ripemd160/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ripemd160/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/ripemd160/node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ripemd160/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/ripemd160/node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
@@ -23283,7 +23062,7 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -23373,10 +23152,10 @@
 			}
 		},
 		"node_modules/schema-utils": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
-			"integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
-			"dev": true,
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
@@ -23385,7 +23164,7 @@
 				"ajv-keywords": "^5.1.0"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 10.13.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -23393,10 +23172,10 @@
 			}
 		},
 		"node_modules/schema-utils/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-			"dev": true,
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -23413,7 +23192,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
 			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3"
@@ -23426,7 +23205,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/semantic-release": {
@@ -23853,16 +23632,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-			"devOptional": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
-			}
-		},
 		"node_modules/serve-static": {
 			"version": "1.16.2",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
@@ -23934,17 +23703,24 @@
 			"license": "ISC"
 		},
 		"node_modules/sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+			"integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
 			"dev": true,
 			"license": "(MIT AND BSD-3-Clause)",
 			"dependencies": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "^2.0.4",
+				"safe-buffer": "^5.2.1",
+				"to-buffer": "^1.2.0"
 			},
 			"bin": {
 				"sha.js": "bin.js"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/sharp": {
@@ -24010,16 +23786,73 @@
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
 				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.4",
-				"object-inspect": "^1.13.1"
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -25047,13 +24880,17 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/telejson": {
@@ -25128,17 +24965,16 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.10",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
-			"integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
-			"devOptional": true,
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+			"integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.20",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
-				"schema-utils": "^3.1.1",
-				"serialize-javascript": "^6.0.1",
-				"terser": "^5.26.0"
+				"schema-utils": "^4.3.0",
+				"terser": "^5.31.1"
 			},
 			"engines": {
 				"node": ">= 10.13.0"
@@ -25151,34 +24987,42 @@
 				"webpack": "^5.1.0"
 			},
 			"peerDependenciesMeta": {
+				"@minify-html/node": {
+					"optional": true
+				},
 				"@swc/core": {
+					"optional": true
+				},
+				"@swc/css": {
+					"optional": true
+				},
+				"@swc/html": {
+					"optional": true
+				},
+				"clean-css": {
+					"optional": true
+				},
+				"cssnano": {
+					"optional": true
+				},
+				"csso": {
 					"optional": true
 				},
 				"esbuild": {
 					"optional": true
 				},
+				"html-minifier-terser": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
 				"uglify-js": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-			"devOptional": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/terser/node_modules/acorn": {
@@ -25375,24 +25219,49 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^6.1.86"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tmp": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-			"integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+			"integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.14"
 			}
 		},
-		"node_modules/to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+		"node_modules/to-buffer": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+			"integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"isarray": "^2.0.5",
+				"safe-buffer": "^5.2.1",
+				"typed-array-buffer": "^1.0.3"
+			},
 			"engines": {
-				"node": ">=4"
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -25428,29 +25297,16 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"psl": "^1.1.33",
-				"punycode": "^2.1.1",
-				"universalify": "^0.2.0",
-				"url-parse": "^1.5.3"
+				"tldts": "^6.1.32"
 			},
 			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/tough-cookie/node_modules/universalify": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.0.0"
+				"node": ">=16"
 			}
 		},
 		"node_modules/traverse": {
@@ -25721,15 +25577,15 @@
 			}
 		},
 		"node_modules/typed-array-buffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-			"integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bound": "^1.0.3",
 				"es-errors": "^1.3.0",
-				"is-typed-array": "^1.1.13"
+				"is-typed-array": "^1.1.14"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -26104,9 +25960,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"devOptional": true,
 			"funding": [
 				{
@@ -26125,7 +25981,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"escalade": "^3.2.0",
-				"picocolors": "^1.1.0"
+				"picocolors": "^1.1.1"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -26138,7 +25994,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
@@ -26166,17 +26022,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			}
-		},
-		"node_modules/url-parse": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"querystringify": "^2.1.1",
-				"requires-port": "^1.0.0"
 			}
 		},
 		"node_modules/url/node_modules/punycode": {
@@ -26222,6 +26067,17 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/validate-npm-package-license": {
@@ -26316,13 +26172,12 @@
 			}
 		},
 		"node_modules/watchpack": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+			"integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
 			},
 			"engines": {
@@ -26330,35 +26185,32 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.95.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
-			"integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
+			"version": "5.109.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.0.tgz",
+			"integrity": "sha512-vomrngskVVXEZF9sMZfYAd4pXZUnfaWdJGlF+BTNF+gJBCKYCQBnOeVPlrh39Ewl7nlCsirDplMy6o5g9xJHBg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/estree": "^1.0.5",
-				"@webassemblyjs/ast": "^1.12.1",
-				"@webassemblyjs/wasm-edit": "^1.12.1",
-				"@webassemblyjs/wasm-parser": "^1.12.1",
-				"acorn": "^8.7.1",
-				"acorn-import-attributes": "^1.9.5",
-				"browserslist": "^4.21.10",
+				"@types/estree": "^1.0.8",
+				"@types/json-schema": "^7.0.15",
+				"@webassemblyjs/ast": "^1.14.1",
+				"@webassemblyjs/wasm-edit": "^1.14.1",
+				"@webassemblyjs/wasm-parser": "^1.14.1",
+				"acorn": "^8.16.0",
+				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.1",
-				"es-module-lexer": "^1.2.1",
+				"enhanced-resolve": "^5.24.2",
+				"es-module-lexer": "^2.1.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
-				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
-				"json-parse-even-better-errors": "^2.3.1",
-				"loader-runner": "^4.2.0",
-				"mime-types": "^2.1.27",
+				"mime-db": "^1.54.0",
+				"minimizer-webpack-plugin": "^5.6.1",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.2.0",
-				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.3.10",
-				"watchpack": "^2.4.1",
-				"webpack-sources": "^3.2.3"
+				"schema-utils": "^4.3.3",
+				"tapable": "^2.3.0",
+				"watchpack": "^2.5.2",
+				"webpack-sources": "^3.5.1"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -26449,9 +26301,9 @@
 			}
 		},
 		"node_modules/webpack-bundle-analyzer/node_modules/ws": {
-			"version": "7.5.10",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+			"integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.3.0"
@@ -26524,9 +26376,9 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+			"integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -26541,16 +26393,16 @@
 			"license": "MIT"
 		},
 		"node_modules/webpack/node_modules/@types/estree": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/webpack/node_modules/acorn": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
-			"integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"devOptional": true,
 			"license": "MIT",
 			"bin": {
@@ -26560,15 +26412,12 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/webpack/node_modules/acorn-import-attributes": {
-			"version": "1.9.5",
-			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+		"node_modules/webpack/node_modules/es-module-lexer": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
 			"devOptional": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"acorn": "^8"
-			}
+			"license": "MIT"
 		},
 		"node_modules/webpack/node_modules/eslint-scope": {
 			"version": "5.1.1",
@@ -26594,23 +26443,14 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/webpack/node_modules/schema-utils": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+		"node_modules/webpack/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
-			},
 			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/which": {
@@ -26693,16 +26533,18 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-			"integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+			"version": "1.1.22",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+			"integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.7",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
+				"call-bind": "^1.0.9",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
 				"has-tostringtag": "^1.0.2"
 			},
 			"engines": {
@@ -26834,9 +26676,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -26883,9 +26725,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"emailjs-com": "3.2.0",
 		"framer-motion": "11.9.0",
 		"graphql": "16.9.0",
-		"next": "14.2.13",
+		"next": "14.2.35",
 		"next-share": "0.27.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "wiebecool",
 	"version": "1.2.0",
 	"private": true,
+	"engines": {
+		"node": ">=24.18.0"
+	},
 	"scripts": {
 		"prepare": "husky",
 		"dev": "next dev",


### PR DESCRIPTION
## Summary
- Bumps `next` 14.2.13 → 14.2.35 (latest stable 14.2.x patch — the Dependabot-suggested 14.2.22 itself had a disclosed vulnerability)
- Runs a non-breaking `npm audit fix`: resolves `cross-spawn` and `nanoid` fully, downgrades `elliptic` from critical to low
- Adds `engines.node` to `package.json` so Vercel deployments target the same Node version as `.nvmrc` (24.18.0)
- Critical vulnerabilities: 9 → 2. Remaining two (`swiper`, `tar`) need major-version bumps with no safe fix available — deferred to a later stage.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Full Cypress suite: 48/48 passing (matches pre-change baseline, no regressions)