### PR TITLE
fix: use correct secret for EmailJS template ID in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
                   wait-on: 'http://localhost:3000'
               env:
                   NEXT_PUBLIC_EMAILJS_SERVICE_ID: ${{ secrets.NEXT_PUBLIC_EMAILJS_SERVICE_ID }}
-                  NEXT_PUBLIC_EMAILJS_TEMPLATE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+                  NEXT_PUBLIC_EMAILJS_TEMPLATE_ID: ${{ secrets.NEXT_PUBLIC_EMAILJS_TEMPLATE_ID }}
                   NEXT_PUBLIC_EMAILJS_USER_ID: ${{ secrets.NEXT_PUBLIC_EMAILJS_USER_ID }}
                   CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
                   CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

- `NEXT_PUBLIC_EMAILJS_TEMPLATE_ID` in the Cypress job's env block was sourced from the `CONTENTFUL_SPACE_ID` secret instead of its own dedicated secret — a copy-paste slip, spotted while reviewing `.github/workflows/test.yml` during the recent maintenance pass.

## Test plan

- [ ] CI run on this PR uses the corrected secret reference — confirm the Cypress job still passes (this is the actual verification, since a wrong secret value here wouldn't necessarily fail the build, only silently break EmailJS-dependent behavior at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)