### PR TITLE
fix: scope CI concurrency group per-branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
             - main
 
 concurrency:
-    group: main-workflow
+    group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- \`.github/workflows/test.yml\`'s concurrency group was a hardcoded literal (\`main-workflow\`), so any push to any branch would cancel any other branch's in-progress run — not just a newer push to the same branch, which is the actual intent of \`cancel-in-progress\`.
- Scoped it to \`${{ github.workflow }}-${{ github.ref }}\` so cancellation only applies to a newer push on the *same* branch; unrelated branches now run independently.

Found while investigating why PR #115's post-merge CI run on \`develop\` and PR #116's own branch CI run both showed as cancelled around the same time — turned out to be this, not an actual problem with either change.

## Test plan

- [ ] This PR's own CI run completes normally
- [ ] Push another branch while this PR's run is in flight (or just observe that this run and any concurrent one no longer cancel each other)

🤖 Generated with [Claude Code](https://claude.com/claude-code)