### PR TITLE
fix: grant explicit permissions to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
     release:
         name: Release
         runs-on: ubuntu-22.04
+        permissions:
+            contents: write
+            issues: write
+            pull-requests: write
         steps:
             - name: Checkout Repository
               uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

`semantic-release` hasn't successfully tagged a release since **v1.1.2** (Oct 28, 2024), even though the release workflow keeps running on pushes to `main`. Evidence:

- Every release from `v0.1.0` through `v1.1.2` has a matching git tag, auto-created by a successful `semantic-release` run.
- On Nov 1, 2024, `semantic-release-bot` made **four separate `chore(release): 1.2.0 [skip ci]` commits**, ~15–25 minutes apart, all computing the identical version bump — with no `v1.2.0` tag ever created. That's the signature of a release completing the version-bump commit but failing before it can create/push the tag and GitHub release.
- The only release-workflow run GitHub still has a record of (Aug 2025, logs since expired) also shows `conclusion: failure`.
- The job in [.github/workflows/release.yml](.github/workflows/release.yml) never declared a `permissions` block, so `GITHUB_TOKEN` fell back to whatever the repo's default token permissions are. If that default is read-only, `semantic-release` can commit the version bump via its own git config but fails exactly at tag/release creation (which needs `contents: write`) — matching this failure signature precisely.

## Fix

Add an explicit `permissions` block to the release job: `contents: write`, `issues: write`, `pull-requests: write` (the standard set `semantic-release`'s own docs recommend, covering `@semantic-release/git`'s commit-back, `@semantic-release/github`'s release/tag creation, and its optional issue/PR commenting). Explicit permissions always override repo/org defaults, so this is safe regardless of what the current default actually is.

`semantic-release` computes the next version from git tags (not `package.json`), so once this runs successfully it will self-correct `package.json`'s stale `"1.2.0"` to whatever the real next version is — no manual version edit needed here.

## Test plan

- [x] This PR's own CI (`test.yml`) is unrelated to the actual fix — it only runs on non-`main` pushes, so it can't exercise the release job itself.
- [ ] **Real verification only happens the next time `develop` is merged into `main`** — watch that the `Release` workflow run completes successfully and a new `v*` tag + GitHub release actually appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)