### PR TITLE
fix: persist cookie consent beyond the browser session

### DIFF
--- a/components/CookieBar.tsx
+++ b/components/CookieBar.tsx
@@ -19,7 +19,9 @@ export const CookieBar: React.FC = () => {
 
 	const acceptCookie = React.useCallback(() => {
 		setShowConsent(true);
-		setCookie(cookieKey, 'true', {});
+		// without an explicit maxAge this becomes a session cookie, wiped when
+		// the browser closes, so the accepted consent wasn't actually remembered
+		setCookie(cookieKey, 'true', { maxAge: 60 * 60 * 24 * 365 });
 	}, []);
 
 	if (showConsent) {

--- a/cypress/e2e/cookies.cy.ts
+++ b/cypress/e2e/cookies.cy.ts
@@ -20,4 +20,14 @@ describe('CookieBar', () => {
 		cy.contains('Accepteer Cookies').click();
 		cy.getCookie('localConsent').should('have.property', 'value', 'true');
 	});
+
+	it('should persist the consent cookie beyond the browser session', () => {
+		// a session cookie (no maxAge/expires) is wiped when the browser closes,
+		// silently undoing an already-accepted consent - assert it's long-lived
+		cy.contains('Accepteer Cookies').click();
+		cy.getCookie('localConsent').then((cookie) => {
+			const oneWeekFromNow = Date.now() / 1000 + 60 * 60 * 24 * 7;
+			expect(cookie?.expiry).to.be.a('number').and.be.greaterThan(oneWeekFromNow);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Investigated a report that the cookie consent bar seemed "bugged". Root cause found in [components/CookieBar.tsx](components/CookieBar.tsx): `setCookie(cookieKey, 'true', {})` never passed a `maxAge`/`expires`. Traced through `cookies-next`'s source (`setCookie` forwards options straight into `cookie.serialize()`) — with an empty options object, no `Max-Age`/`Expires` attribute gets written at all, so the browser treats it as a **session cookie**. Confirmed live via the `cookieStore` API: without the fix the cookie simply doesn't have a persistent expiry, so it's wiped as soon as the browser closes. A visitor who clicked "Accept" would see the bar reappear on every new browser session, even though they'd already consented.

## Fix

Pass an explicit 1-year `maxAge` (`60 * 60 * 24 * 365` seconds), the standard convention for cookie-consent duration. Verified via the browser's `cookieStore.get()` API that the cookie now actually carries an expiry ~365 days out.

## Test plan

- [x] Manual repro in a real browser: cleared cookies, confirmed bar shows, accepted, confirmed `cookieStore.get('localConsent').expires` is ~1 year out (was previously undefined/session-only)
- [x] Added a Cypress regression test asserting the cookie's `expiry` is far in the future — confirmed it **fails** against the old `{}` code and **passes** against the fix, by temporarily reverting and re-running
- [x] `npm run lint`, `npm run build` clean
- [x] Cold `rm -rf .next && npm run build && npm start` + `npx cypress run --e2e` — 49/49 passing (48 existing + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)